### PR TITLE
Add websocket close and return to client

### DIFF
--- a/src/websocket_manager.rs
+++ b/src/websocket_manager.rs
@@ -129,6 +129,7 @@ impl StreamHandler<Result<ws::Message, ws::ProtocolError>> for WebsocketActor {
                 ctx.text(text);
             }
             Ok(ws::Message::Binary(bin)) => ctx.binary(bin),
+            Ok(ws::Message::Close(msg)) => ctx.close(msg),
             _ => (),
         }
     }


### PR DESCRIPTION
Tested with few connection/disconnetion commands using postman client.

Before:
Delay something around 1~3 minutes then disconnect with abnormal reason.
![image](https://github.com/mavlink/mavlink2rest/assets/80598030/2eb51411-0da0-4070-83fb-a4470f9c021e)
![image](https://github.com/mavlink/mavlink2rest/assets/80598030/e2e74a0f-fe47-422d-b7e8-6f9269e93210)

Now:
Disconnect and send reason right after close command.
![Screenshot from 2024-02-28 10-42-58](https://github.com/mavlink/mavlink2rest/assets/80598030/cbf71741-fba0-41df-8737-c13864c085c3)
![Screenshot from 2024-02-28 10-42-39](https://github.com/mavlink/mavlink2rest/assets/80598030/ed12e3ca-6275-4c02-a666-e8d651fad7b0)
